### PR TITLE
Apply GitHub mirror patch with dowhen

### DIFF
--- a/esphome/__init__.py
+++ b/esphome/__init__.py
@@ -1,0 +1,4 @@
+"""ESPHome package initialization with GitHub URL rewriting."""
+
+# Importing applies monkeypatches for GitHub requests using dowhen.
+from . import github_mirror  # noqa: F401

--- a/esphome/github_mirror.py
+++ b/esphome/github_mirror.py
@@ -1,0 +1,45 @@
+import os
+import requests
+
+from dowhen import when
+
+# Base URL used as prefix for GitHub requests
+CUSTOM_URL = os.environ.get("CUSTOM_GITHUB_URL", "https://gh.161024.xyz")
+
+
+def _transform_url(url: str) -> str:
+    """Prefix GitHub URLs with the custom mirror."""
+    if url.startswith(CUSTOM_URL):
+        return url
+    if "github.com" in url:
+        return f"{CUSTOM_URL}/{url}"
+    return url
+
+
+# Patch requests.Session.request
+def _patch_requests(url):
+    new_url = _transform_url(url)
+    if new_url != url:
+        return {"url": new_url}
+
+when(requests.sessions.Session.request, "<start>").do(_patch_requests)
+
+
+# Patch git command execution
+try:
+    from esphome.git import run_git_command
+except Exception:  # pragma: no cover
+    run_git_command = None
+
+if run_git_command is not None:
+    def _patch_git(cmd):
+        patched = False
+        for i, arg in enumerate(cmd):
+            if isinstance(arg, str) and "github.com" in arg and not arg.startswith(CUSTOM_URL):
+                cmd[i] = f"{CUSTOM_URL}/{arg}"
+                patched = True
+        if patched:
+            return {"cmd": cmd}
+
+    when(run_git_command, "<start>").do(_patch_git)
+


### PR DESCRIPTION
## Summary
- patch `requests` and git commands using dowhen
- auto-load patch during module import

## Testing
- `pytest -q tests/unit_tests`

------
https://chatgpt.com/codex/tasks/task_e_68627b55d95c8327843b58446285a96b