### PR TITLE
Add platformio HTTP client patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,17 @@ export CUSTOM_GITHUB_URL="https://mirror.example.com"
 ```
 
 ## 使用方法
-在任何脚本中导入本项目即可自动生效：
+在任何脚本中导入本项目即可自动生效，或直接使用命令行工具 `esphome-cn`：
 
 ```python
 import esphome
+
+```
+
+运行示例：
+
+```bash
+esphome-cn run livingroom.yaml
 ```
 
 此后无论是 `requests` 还是 `git` 操作，只要包含 `github.com` 都会被重写到镜像地址。

--- a/esphome/github_mirror.py
+++ b/esphome/github_mirror.py
@@ -1,7 +1,17 @@
 import os
-import requests
 
 from dowhen import when
+import requests
+
+try:
+    from platformio.http import HTTPClient, HTTPSession
+    from platformio.package.vcsclient import VCSClientFactory
+except Exception:  # pragma: no cover
+    HTTPSession = None
+    HTTPClient = None
+    VCSClientFactory = None
+
+import subprocess
 
 # Base URL used as prefix for GitHub requests
 CUSTOM_URL = os.environ.get("CUSTOM_GITHUB_URL", "https://gh.161024.xyz")
@@ -22,7 +32,26 @@ def _patch_requests(url):
     if new_url != url:
         return {"url": new_url}
 
+
 when(requests.sessions.Session.request, "<start>").do(_patch_requests)
+
+
+def _patch_subprocess(cmd, *args, **kwargs):
+    if (
+        isinstance(cmd, (list, tuple))
+        and len(cmd) >= 3
+        and cmd[1:3] == ["-m", "pip"]
+        and cmd[3:4] == ["list"]
+    ):
+        return {"stdout": b"[]"}
+
+
+when(subprocess.check_output, "<start>").do(_patch_subprocess)
+
+if HTTPSession is not None:
+    when(HTTPSession.request, "<start>").do(
+        lambda self, method, url, *args, **kwargs: {"url": _transform_url(url)}
+    )
 
 
 # Patch git command execution
@@ -32,10 +61,15 @@ except Exception:  # pragma: no cover
     run_git_command = None
 
 if run_git_command is not None:
+
     def _patch_git(cmd):
         patched = False
         for i, arg in enumerate(cmd):
-            if isinstance(arg, str) and "github.com" in arg and not arg.startswith(CUSTOM_URL):
+            if (
+                isinstance(arg, str)
+                and "github.com" in arg
+                and not arg.startswith(CUSTOM_URL)
+            ):
                 cmd[i] = f"{CUSTOM_URL}/{arg}"
                 patched = True
         if patched:
@@ -43,3 +77,26 @@ if run_git_command is not None:
 
     when(run_git_command, "<start>").do(_patch_git)
 
+if VCSClientFactory is not None:
+    when(VCSClientFactory.new, "<start>").do(
+        lambda src_dir, remote_url, **kwargs: {"remote_url": _transform_url(remote_url)}
+    )
+
+if HTTPClient is not None:
+
+    def _patch_httpclient_init(endpoints, **kwargs):
+        if isinstance(endpoints, (list, tuple)):
+            endpoints = [_transform_url(e) for e in endpoints]
+        else:
+            endpoints = _transform_url(endpoints)
+        return {"endpoints": endpoints}
+
+    when(HTTPClient.__init__, "<start>").do(
+        lambda self, endpoints, *args, **kwargs: _patch_httpclient_init(
+            endpoints, **kwargs
+        )
+    )
+
+    when(HTTPClient.send_request, "<start>").do(
+        lambda self, method, path, **kwargs: {"path": _transform_url(path)}
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools==80.9.0", "wheel>=0.43,<0.46"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name        = "esphome"
+name        = "esphome-cn"
 license     = {text = "MIT"}
 description = "ESPHome is a system to configure your microcontrollers by simple yet powerful configuration files and control them remotely through Home Automation systems."
 readme      = "README.md"
@@ -35,6 +35,7 @@ dynamic = ["dependencies", "optional-dependencies", "version"]
 
 [project.scripts]
 esphome = "esphome.__main__:main"
+esphome-cn = "esphome.__main__:main"
 
 [tool.setuptools]
 platforms            = ["any"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ voluptuous==0.15.2
 PyYAML==6.0.2
 paho-mqtt==1.6.1
 colorama==0.4.6
+dowhen==0.1.0
 icmplib==3.0.4
 tornado==6.5.1
 tzlocal==5.3.1    # from time


### PR DESCRIPTION
## Summary
- expose esphome-cn CLI in README
- rename distribution to `esphome-cn`
- monkeypatch PlatformIO HTTP client so GitHub URLs use mirror
- intercept pip list calls to avoid errors

## Testing
- `pre-commit run --files esphome/github_mirror.py README.md pyproject.toml requirements.txt`
- `pytest -k github_mirror -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_68629106789483278086e32918bf3571