### PR TITLE
Fix git mirror for submodules

### DIFF
--- a/esphome/github_mirror.py
+++ b/esphome/github_mirror.py
@@ -1,5 +1,8 @@
 import os
 import re
+import subprocess
+import shlex
+from pathlib import Path
 
 from dowhen import when
 import requests
@@ -82,3 +85,32 @@ if HTTPClient is not None:
             endpoints, **kwargs
         )
     )
+
+# Patch generic git commands executed via subprocess
+def _patch_popen(args, **kwargs):
+    """Rewrite GitHub URLs when git commands are executed."""
+    def _handle_list(lst):
+        patched = False
+        for i, arg in enumerate(lst):
+            if isinstance(arg, str):
+                new_arg = _transform_url(arg)
+                if new_arg != arg:
+                    lst[i] = new_arg
+                    patched = True
+        return patched
+
+    # args can be a sequence or string
+    if isinstance(args, (list, tuple)):
+        if args and isinstance(args[0], str) and Path(args[0]).stem.lower() == "git":
+            args = list(args)
+            if _handle_list(args):
+                return {"args": args}
+    elif isinstance(args, str):
+        parts = shlex.split(args)
+        if parts and Path(parts[0]).stem.lower() == "git":
+            if _handle_list(parts):
+                args = " ".join(shlex.quote(p) for p in parts)
+                return {"args": args}
+
+
+when(subprocess.Popen.__init__, "<start>").do(_patch_popen)

--- a/tests/unit_tests/test_github_mirror.py
+++ b/tests/unit_tests/test_github_mirror.py
@@ -1,5 +1,5 @@
 import os
-from esphome.github_mirror import _transform_url, CUSTOM_URL
+from esphome.github_mirror import _transform_url, CUSTOM_URL, _patch_popen
 
 
 def test_transform_url_git_plus():
@@ -11,3 +11,15 @@ def test_transform_url_git_plus():
 def test_transform_url_already_patched():
     url = f"git+{CUSTOM_URL}/https://github.com/example/repo.git"
     assert _transform_url(url) == url
+
+
+def test_patch_popen_list():
+    args = ["git", "clone", "https://github.com/example/repo.git"]
+    result = _patch_popen(args)
+    assert result["args"][2] == f"{CUSTOM_URL}/https://github.com/example/repo.git"
+
+
+def test_patch_popen_string():
+    cmd = "git clone https://github.com/example/repo.git"
+    result = _patch_popen(cmd)
+    assert f"{CUSTOM_URL}/https://github.com/example/repo.git" in result["args"]


### PR DESCRIPTION
## Summary
- handle git commands started directly via `subprocess.Popen`
- add tests for the new helper

## Testing
- `pip install -r requirements_test.txt`
- `pip install -r requirements.txt`
- `pytest` *(fails: 22 failed, 570 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6862ba7de978832786f73fca68c481a7